### PR TITLE
Revisões propostas no comentário do vídeo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+*.mp4
+
+settings.ini

--- a/load_im.py
+++ b/load_im.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import time
+from configparser import ConfigParser
+from tkinter import filedialog, Tk
+
+CONFIG_FILE_NAME = 'settings.ini'
+CONFIG_IMAGEMAGICK_FILE = 'imagemagick_file_name'
+
+def _open_dialog_file():
+	"""Abre uma janela de diálogo para selecionar o magick.exe no diretório do ImageMagick
+	
+		retorno: o caminho do arquivo
+	"""
+	
+	file_types = [('Arquivo executável', '*.exe')]
+	file_name = None
+	title = 'Selecione o arquivo executável do ImageMagick (magick.exe)'
+	
+	root = Tk()
+	root.withdraw()
+	root.filename = filedialog.askopenfilename(initialdir = os.getcwd(), title = title, filetypes = file_types)	
+	file_name = root.filename
+	root.destroy()
+	
+	return file_name 
+
+
+def _create_file(file_name):
+	"""Cria um arquivo de configuração (config.ini) e amarmazena o caminho do magick.exe nele
+	
+		file_name: caminho do magick.exe
+	"""
+	config = ConfigParser()
+	config['DEFAULT'] = { CONFIG_IMAGEMAGICK_FILE: file_name }
+	
+	with open(CONFIG_FILE_NAME, 'w') as f:
+		config.write(f)
+
+
+def _read_file():
+	"""Lê o arquivo de configuração (config.ini)
+	
+		retorno: o caminho do magick.exe
+	"""
+	config = ConfigParser()
+	config.read(CONFIG_FILE_NAME)
+	return config['DEFAULT'].get(CONFIG_IMAGEMAGICK_FILE)
+
+
+def get_image_magick_executable():
+	"""Retorna o caminho do magick.exe definido no settings.ini. Se settings.init não estiver definido então pergunta o caminho e abre uma janela de diálogo e então grava esse caminho no settings.ini.
+	
+		Mata o programa se nada for selecionado na janela de diálogo
+		
+		retorno: o caminho do magick.exe
+	"""
+	if os.path.exists(CONFIG_FILE_NAME):
+		im_filename = _read_file()
+	else:
+		print('Selecione o executável do ImageMagick na pasta em que você o instalou:')
+		time.sleep(1)
+		
+		im_filename = _open_dialog_file()
+		if (im_filename == ''):
+			print('Nenhum arquivo selecionado')
+			sys.exit(1)
+		
+		_create_file(im_filename)
+	
+	return im_filename

--- a/main.py
+++ b/main.py
@@ -167,19 +167,34 @@ def deleteTempFiles():
                 os.remove(file)
 
 
+def parse_args():
+    parser = ArgumentParser(description = 'Remove os pedaços silenciosos do video.')
+    parser.add_argument('file', help = 'arquivo de vídeo mp4')
+    parser.add_argument('-r', action = 'store', dest = 'rs', type = int, default = 900, required = False,
+                        help = 'limiar que demarca intensidade de silêncio')
+    parser.add_argument('-t', action = 'store', dest = 'ts', type = int, default = 250, required = False,
+                        help = 'tempo mínimo de silêncio em milissegundos')
+    parser.add_argument('--d', action = 'store_true', dest = 'debug', required = False, help = 'mode debug')
+    
+    return parser.parse_args()
+
+
 def main():
-	
+    arguments = parse_args()
+    
+    if not os.path.exists(arguments.file):
+        print(f'{arguments.file} não existe.')
+        return
+    
     #initializeMoviePy() # TODO: descomentar e adc flag no settings para só executar isso na 1a vez
 	
 	# define o caminho do imagehack em runtime
     config_defaults.IMAGEMAGICK_BINARY = get_image_magick_executable()
-
-    #passe aqui o nome do arquivo de vídeo, o limiar que demarca intensidade de silêncio (900 é um bom valor) e oq seria uma boa
-    #duração de silêncio (coloquei 250 ms alí)
-    identifySilenceMomentsOfVideo("pythonfazpramim1-2.mp4", 900, 250, debug = False)
+    
+    identifySilenceMomentsOfVideo(arguments.file, arguments.rs, arguments.ts, debug = arguments.debug)
 
     #essa função abaixo clipa o vídeo original passado por parâmetro de acordo com a informação de silêncio no arquivo de log
-    clipSilenceBasedOnTxtFile("pythonfazpramim1-2.mp4", "silenceToRemoveCOPY.txt", debug = False)
+    clipSilenceBasedOnTxtFile("pythonfazpramim1-2.mp4", "silenceToRemoveCOPY.txt", debug = arguments.debug)
 
     deleteTempFiles()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pydub==0.23.1
+moviepy==1.0.1
+termcolor==1.1.0


### PR DESCRIPTION
- mode agora é um boolean
- adicionado gitignore e requirements
- o programa abrirá uma dialog box e pedirá que seja selecionado o magick.exe no lugar de andar pelo disco C: procurando
- valor de config_defaults.py.IMAGEMAGICK_BINARY alterado dinamicamente. O arquivo não é mais alterado.
- o caminho será gravado em um arquivo para futuros usos
- configurações como o nome do arquivo e se é para ser executado em debug agora passados por argumentos de linha de comando.

Eu não toquei nos métodos responsáveis pela funcionalidade principal por eu não ter conseguido executa-las por problemas relacionados com meu ambiente.